### PR TITLE
RK-20643 - use m1 instead of EOL x86 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     macos:
       xcode: "15.0.0"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - restore_cache:
@@ -81,7 +81,7 @@ jobs:
   version_validation:
     macos:
       xcode: "15.0.0"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
https://circleci.com/changelog/macos-resource-eol/

Before merging the PR, please bump up the version in `package.json`.
