### PR TITLE
Added missing types for cors package

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/auto-launch": "^5.0.0",
     "@types/aws-lambda": "^8.10.17",
     "@types/body-parser": "^1.17.0",
+    "@types/cors": "^2.8.17",
     "@types/lodash": "^4.14.182",
     "@types/node": "^20.12.2",
     "@types/node-fetch": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,6 +611,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@^2.8.17":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/debug@^4.1.6":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"


### PR DESCRIPTION
For some reason, the app decided it's missing type declarations now. No clue how it passed builds previously. I added them in.
