### PR TITLE
RK-20838 - Changed default localhost origin for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-desktop-application",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "dynatrace desktop application's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -2,7 +2,7 @@ import * as cors from "cors";
 import fetch from "node-fetch";
 
 
-const LOCALHOST_ORIGIN = "https://localhost:8080";
+const LOCALHOST_ORIGIN = "http://localhost:3000";
 const DYNATRACE_ORIGIN_REGEX = /^https:\/\/.*\.dynatrace(?:labs)?\.com(?::\d+)?$/;
 
 const ALLOW_CORS_OPTION: cors.CorsOptions = {origin: true};


### PR DESCRIPTION
We no longer develop on `https://localhost:8080` by default, so I changed it to the current development host for CORS
