### PR TITLE
APPOBS-9000/upgrade node version in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
-version: 2
+version: 2.1
 references:
   filter_master: &filter_master
     filters:
       branches:
         only: master
-
+orbs:
+  node: circleci/node@7.1.0
 
 jobs:
   publish:
@@ -17,6 +18,9 @@ jobs:
           command: |
             softwareupdate --install-rosetta --agree-to-license
       - checkout
+      - node/install:
+          install-yarn: true
+          node-version: "22.14.0"
       - restore_cache:
           key: homebrew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}-{{ checksum ".circleci/config.yml" }}
       - run:


### PR DESCRIPTION
To fix a vulnerability, I updated `@apollo/server` to version 5, but it's not compatible with node 18 (what's currently running in CircleCI), so this is an attempt to update the version of node