### PR TITLE
NOISSUE/Fix deprecated resource config in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ orbs:
 jobs:
   publish:
     macos:
-      xcode: "15.0.0"
-    resource_class: macos.m1.large.gen1
+      xcode: "26.3.0"
+    resource_class: m4pro.medium
     steps:
       - run:
           name: Install Rosetta 2
@@ -89,8 +89,8 @@ jobs:
             - /usr/local/Homebrew
   version_validation:
     macos:
-      xcode: "15.0.0"
-    resource_class: macos.m1.large.gen1
+      xcode: "26.3.0"
+    resource_class: m4pro.medium
     steps:
       - run:
           name: Install Rosetta 2


### PR DESCRIPTION
According to [CircleCI docs](https://circleci.com/docs/guides/execution-managed/using-macos/), we're using resource classes and XCode versions that no longer exist. This PR updates them to the current ones available.