### PR TITLE
APPOBS-32684: Add host allowlist middleware to local HTTP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-desktop-application",
-  "version": "1.0.18",
+  "version": "1.1.0",
   "description": "dynatrace desktop application's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,5 +1,6 @@
 import * as cors from "cors";
 import fetch from "node-fetch";
+import type {Request, Response, NextFunction} from "express";
 
 
 const LOCALHOST_ORIGIN = "http://localhost:3000";
@@ -42,5 +43,21 @@ const corsOptionsDelegate = async (req: cors.CorsRequest, callback: (err: Error 
 
 export const getCorsMiddleware = () => {
     return cors(corsOptionsDelegate);
+};
+
+const ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+export const hostAllowlistMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    const hostHeader = req.headers.host;
+    if (!hostHeader) {
+        res.status(400).send("Missing Host header");
+        return;
+    }
+    const host = hostHeader.replace(/:\d+$/, "");
+    if (!ALLOWED_HOSTS.has(host)) {
+        res.status(403).send("Forbidden");
+        return;
+    }
+    next();
 };
 

--- a/src/middleware/allowedHosts.ts
+++ b/src/middleware/allowedHosts.ts
@@ -1,0 +1,19 @@
+import type {Request, Response, NextFunction} from "express";
+
+
+const ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+const PORT_REGEX = /:\d+$/;
+
+export const allowedHostsMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    const hostHeader = req.headers.host;
+    if (!hostHeader) {
+        res.status(400).send("Missing Host header");
+        return;
+    }
+    const host = hostHeader.replace(PORT_REGEX, "");
+    if (!ALLOWED_HOSTS.has(host)) {
+        res.status(403).send("Forbidden");
+        return;
+    }
+    next();
+};

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,6 +1,5 @@
 import * as cors from "cors";
 import fetch from "node-fetch";
-import type {Request, Response, NextFunction} from "express";
 
 
 const LOCALHOST_ORIGIN = "http://localhost:3000";
@@ -43,21 +42,5 @@ const corsOptionsDelegate = async (req: cors.CorsRequest, callback: (err: Error 
 
 export const getCorsMiddleware = () => {
     return cors(corsOptionsDelegate);
-};
-
-const ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
-
-export const hostAllowlistMiddleware = (req: Request, res: Response, next: NextFunction) => {
-    const hostHeader = req.headers.host;
-    if (!hostHeader) {
-        res.status(400).send("Missing Host header");
-        return;
-    }
-    const host = hostHeader.replace(/:\d+$/, "");
-    if (!ALLOWED_HOSTS.has(host)) {
-        res.status(403).send("Forbidden");
-        return;
-    }
-    next();
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,13 +8,14 @@ import {applyMiddleware} from "graphql-middleware";
 import * as http from "http";
 import {join} from "path";
 import {resolvers} from "./api";
-import {getCorsMiddleware, hostAllowlistMiddleware} from "./cors";
+import {getCorsMiddleware} from "./middleware/cors";
 import {notify} from "./exceptionManager";
 import {
     filterDirTraversal,
     logMiddleware,
     resolveRepoFromId,
 } from "./middlewares";
+import {allowedHostsMiddleware} from "./middleware/allowedHosts";
 
 export type onAddRepoRequestHandler = (fullpath: string, id?: string) => Promise<boolean>;
 
@@ -64,7 +65,7 @@ export const start = async (options: StartOptions) => {
     await apolloServer.start();
 
     app.use('/',
-        hostAllowlistMiddleware,
+        allowedHostsMiddleware,
         getCorsMiddleware(),
         express.json(),
         expressMiddleware(apolloServer, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import {applyMiddleware} from "graphql-middleware";
 import * as http from "http";
 import {join} from "path";
 import {resolvers} from "./api";
-import {getCorsMiddleware} from "./cors";
+import {getCorsMiddleware, hostAllowlistMiddleware} from "./cors";
 import {notify} from "./exceptionManager";
 import {
     filterDirTraversal,
@@ -64,6 +64,7 @@ export const start = async (options: StartOptions) => {
     await apolloServer.start();
 
     app.use('/',
+        hostAllowlistMiddleware,
         getCorsMiddleware(),
         express.json(),
         expressMiddleware(apolloServer, {


### PR DESCRIPTION
## Summary

- Adds `hostAllowlistMiddleware` to `src/cors.ts` that rejects any request whose `Host` header is not `localhost`, `127.0.0.1`, or `::1`
- Wires the middleware in `src/server.ts` **before** the existing CORS middleware so requests with unexpected `Host` headers are blocked before any GraphQL processing

## Why

The local HTTP server should only ever be reachable via `localhost` or `127.0.0.1`. Adding an explicit host-level filter enforces this invariant at the server layer, complementing the existing origin-based CORS check.

## Reviewer notes

- No changes to the CORS logic itself — this is an additive layer
- The allowlist is intentionally tight (`localhost`, `127.0.0.1`, `::1` only); the server only ever binds to `127.0.0.1:44512`
- Relates to APPOBS-32684

🤖 Generated with [Claude Code](https://claude.com/claude-code)