### PR TITLE
Appobs 32310 upgrade electron   fix linix related config

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,15 +49,11 @@
     "linux": {
       "target": "appImage",
       "category": "Utility",
+      "executableName": "rookout",
       "mimeTypes": [
         "x-scheme-handler/rookout",
         "x-scheme-handler/dynatrace"
-      ],
-      "desktop": {
-        "entry": {
-          "Exec": "rookout %u"
-        }
-      }
+      ]
     },
     "dmg": {
       "background": "assets/dmg-background.png"

--- a/sign_windows.mjs
+++ b/sign_windows.mjs
@@ -11,6 +11,12 @@ export default async function(configuration) {
   const CERTIFICATE_PATH = process.env.WINDOWS_EV_CERTIFICATE_PATH;
   const GOOGLE_HSM_KEY_ID = process.env.GOOGLE_HSM_KEY_ID;
 
+  // Skip signing if credentials are not available (e.g. local builds)
+  if (!CERTIFICATE_PATH || !GOOGLE_HSM_KEY_ID) {
+    console.log('Windows signing: credentials not found - skipping signing');
+    return true;
+  }
+
   const command = [
     "java", "-jar", "jsign.jar",
     "--storetype", "GOOGLE_HSM",


### PR DESCRIPTION
Fix electron-builder 26 Linux & Windows packagin

Linux config: Replaced linux.desktop.entry.Exec with linux.executableName — electron-builder 26 explicitly forbids setting Exec inside the desktop object and requires the executable name to be declared via executableName. Deep link URL handling (%u) is preserved as electron-builder automatically appends it to the generated .desktop file when mimeTypes are present.

Windows signing: Added a credentials guard to sign_windows.mjs so local builds without WINDOWS_EV_CERTIFICATE_PATH and GOOGLE_HSM_KEY_ID skip signing gracefully instead of crashing. Mirrors the equivalent guard already present in afterSignHook.mjs for Mac notarization. CI deployments with credentials are unaffected.