### PR TITLE
Fix adding new repo not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-desktop-application",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "dynatrace desktop application's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,9 @@ function registerIpc() {
   ipcMain.on("pop-choose-repository", () => {
     if (mainWindow) mainWindow.webContents.send("pop-choose-repository");
   });
+  ipcMain.on("add-repo", (e: IpcMainEvent, repo: any) => {
+    if (indexWorker) indexWorker.webContents.send("add-repo", repo);
+  });
 }
 
 


### PR DESCRIPTION
Adding new repo was not working because there was a missing relay from the main process to the webworker
