### PR TITLE
APPOBS-35358/Fix fast-uri CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "graphql-constraint-directive/validator": "^13.6.0",
     "sha.js": "^2.4.12",
     "qs": "^6.14.2",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "fast-uri": "^3.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,10 +2391,10 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@^3.0.1, fast-uri@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
## Summary
- Pins `fast-uri` to `^3.1.2` via yarn `resolutions` to address two Snyk vulnerabilities
- CVE-2026-6321 (Directory Traversal, fixed in 3.1.1+) — APPOBS-35358
- CVE-2026-6322 (Interpretation Conflict / host bypass, fixed in 3.1.2+) — APPOBS-35359

`fast-uri` is a transitive dependency (`ajv` → `fast-uri`); neither is a direct dep. The vulnerabilities are in `normalize()`/`equal()` functions not exercised by our usage (JSON schema format validation only), but pinning removes the Snyk findings.

## Test plan
- [x] `yarn` installs `fast-uri@3.1.2`
- [x] `yarn run build` compiles successfully with no new errors or warnings