### PR TITLE
APPOBS-35380/Ignore @protobufjs/utf8 CVE-2026-44293 (not exploitable)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,4 +9,12 @@ ignore:
           not pass schema (only name/watch), so vulnerable path is unreachable.
         expires: 2026-08-23T00:00:00.000Z
         created: 2026-02-23T19:40:25.431Z
+  SNYK-JS-PROTOBUFJSUTF8-16643422:
+    - '*':
+        reason: >-
+          Not exploitable: @apollo/protobufjs loads a hardcoded schema bundled in
+          @apollo/usage-reporting-protobuf — no user-controlled descriptor is ever
+          loaded, so the crafted-schema attack vector does not exist in this app.
+        expires: 2026-11-17T00:00:00.000Z
+        created: 2026-05-17T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
## Summary
- Adds a Snyk ignore entry for SNYK-JS-PROTOBUFJSUTF8-16643422 (CVE-2026-44293)
- The vulnerability requires an attacker to control the protobuf schema (descriptor) loaded at runtime
- In this app, `@apollo/protobufjs` only ever loads a hardcoded schema bundled inside `@apollo/usage-reporting-protobuf` — no user-controlled descriptor is loaded, so the attack vector is unreachable
- Ignore expires 2026-11-17 for periodic re-evaluation

## Why not upgrade?
Every version of `@apollo/protobufjs` (including latest) declares `@protobufjs/utf8` as `^1.1.0` — upgrading the parent package won't pin to `1.1.1`. A resolutions override would work but isn't warranted given the vulnerability is unexploitable here.

## Test plan
- [ ] Snyk scan no longer flags APPOBS-35380