### PR TITLE
APPOBS-34193: ubuntu24 launch and autostart fixes

### DIFF
--- a/afterPackHook.mjs
+++ b/afterPackHook.mjs
@@ -25,16 +25,16 @@ export default async function (context) {
 
     console.log(`afterPack (Linux): wrapping ${executableName} with --no-sandbox launcher`);
 
-    if (!fs.existsSync(originalBin)) {
-        console.warn(`afterPack (Linux): binary not found at ${originalBin}, skipping`);
-        return;
-    }
-
     // Rename the real binary, then create a wrapper script in its place.
     // $APPDIR is set by AppRun before calling this wrapper, so it is always
     // available. We fall back to the script's own directory for the rare case
     // where the wrapper is invoked directly outside of an AppImage context.
-    fs.renameSync(originalBin, wrappedBin);
+    try {
+        fs.renameSync(originalBin, wrappedBin);
+    } catch (error) {
+        console.warn(`afterPack (Linux): could not wrap ${executableName} — binary not found or inaccessible: ${error.message}`);
+        return;
+    }
 
     fs.writeFileSync(
         originalBin,

--- a/afterPackHook.mjs
+++ b/afterPackHook.mjs
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+// On Linux AppImage builds, Electron's chrome-sandbox requires SUID root
+// permissions which are impossible to set inside a FUSE-mounted AppImage.
+// This causes a FATAL crash on Ubuntu 24+ when the app is launched.
+//
+// The fix: wrap the executable with a shell script that always passes
+// --no-sandbox, so the flag is in effect regardless of how the AppImage
+// is invoked (terminal, file manager, autostart, etc.).
+//
+// Note: executableArgs in package.json only affects the .desktop file embedded
+// in the AppImage (used for desktop integration), NOT the AppRun script that
+// runs when the AppImage is executed directly. This afterPack hook is needed
+// to cover the direct execution case.
+export default async function (context) {
+    if (context.electronPlatformName !== 'linux') {
+        return;
+    }
+
+    const executableName = context.packager.executableName;
+    const appOutDir = context.appOutDir;
+    const originalBin = path.join(appOutDir, executableName);
+    const wrappedBin = path.join(appOutDir, `${executableName}.bin`);
+
+    console.log(`afterPack (Linux): wrapping ${executableName} with --no-sandbox launcher`);
+
+    if (!fs.existsSync(originalBin)) {
+        console.warn(`afterPack (Linux): binary not found at ${originalBin}, skipping`);
+        return;
+    }
+
+    // Rename the real binary, then create a wrapper script in its place.
+    // $APPDIR is set by AppRun before calling this wrapper, so it is always
+    // available. We fall back to the script's own directory for the rare case
+    // where the wrapper is invoked directly outside of an AppImage context.
+    fs.renameSync(originalBin, wrappedBin);
+
+    fs.writeFileSync(
+        originalBin,
+        `#!/bin/bash\nexec "\${APPDIR:-$(dirname "$(readlink -f "$0")")}/${executableName}.bin" --no-sandbox "$@"\n`
+    );
+
+    fs.chmodSync(originalBin, 0o755);
+
+    console.log(`afterPack (Linux): done — ${executableName} now wraps ${executableName}.bin with --no-sandbox`);
+}

--- a/afterPackHook.mjs
+++ b/afterPackHook.mjs
@@ -32,8 +32,7 @@ export default async function (context) {
     try {
         fs.renameSync(originalBin, wrappedBin);
     } catch (error) {
-        console.warn(`afterPack (Linux): could not wrap ${executableName} — binary not found or inaccessible: ${error.message}`);
-        return;
+        throw new Error(`afterPack (Linux): could not wrap ${executableName} — binary not found or inaccessible: ${error.message}`);
     }
 
     fs.writeFileSync(

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "extends": null,
     "appId": "com.rookout.dynatrace-desktop-application",
     "afterSign": "./afterSignHook.mjs",
+    "afterPack": "./afterPackHook.mjs",
+    "toolsets": {
+      "appimage": "1.0.2"
+    },
     "publish": [
       {
         "provider": "github",
@@ -49,7 +53,6 @@
       "target": "appImage",
       "category": "Utility",
       "executableName": "rookout",
-      "executableArgs": ["--no-sandbox"],
       "mimeTypes": [
         "x-scheme-handler/dynatrace"
       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-desktop-application",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "dynatrace desktop application's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       "target": "appImage",
       "category": "Utility",
       "executableName": "rookout",
+      "executableArgs": ["--no-sandbox"],
       "mimeTypes": [
         "x-scheme-handler/dynatrace"
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,18 +80,16 @@ async function enableAutoLaunch() {
   }
 }
 
-/* Electron's bundled chrome-sandbox requires SUID root permissions.
+// On Linux AppImage builds, Electron's chrome-sandbox requires SUID root permissions.
 // Inside an AppImage the filesystem is read-only and user-mounted, so SUID can
 // never be set, causing a FATAL crash on Ubuntu 24+ when the app autostarts.
-// createAutoLaunch builds an AutoLaunch instance and, on Linux AppImage builds,
-// patches opts.appPath to include --no-sandbox after construction.
-// Patching appPath post-construction leaves appName intact while ensuring the
-// Exec= line in the generated .desktop file carries the flag.
-*/
+// createAutoLaunch patches opts.appPath after construction (not during) to inject
+// --no-sandbox into the Exec= line of the generated .desktop autostart file,
+// while leaving appName intact so the .desktop filename remains correct.
 function createAutoLaunch(config: { name: string; isHidden: boolean; path?: string }): AutoLaunch {
   const instance = new AutoLaunch(config);
   if (process.platform === "linux" && process.env.APPIMAGE) {
-    (instance as any).opts.appPath = `${process.env.APPIMAGE} --no-sandbox`;
+    (instance as any).opts.appPath = `"${process.env.APPIMAGE}" --no-sandbox`;
   }
   return instance;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ async function enableAutoLaunch() {
 // Inside an AppImage the filesystem is read-only and user-mounted, so SUID can
 // never be set, causing a FATAL crash on Ubuntu 24+ when the app autostarts.
 // createAutoLaunch builds an AutoLaunch instance and, on Linux AppImage builds,
-// patches opts.appPath to include --no-sandbox AFTER construction.
+// patches opts.appPath to include --no-sandbox after construction.
 // Patching appPath post-construction leaves appName intact while ensuring the
 // Exec= line in the generated .desktop file carries the flag.
 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,22 @@ async function enableAutoLaunch() {
   }
 }
 
+/* Electron's bundled chrome-sandbox requires SUID root permissions.
+// Inside an AppImage the filesystem is read-only and user-mounted, so SUID can
+// never be set, causing a FATAL crash on Ubuntu 24+ when the app autostarts.
+// createAutoLaunch builds an AutoLaunch instance and, on Linux AppImage builds,
+// patches opts.appPath to include --no-sandbox AFTER construction.
+// Patching appPath post-construction leaves appName intact while ensuring the
+// Exec= line in the generated .desktop file carries the flag.
+*/
+function createAutoLaunch(config: { name: string; isHidden: boolean; path?: string }): AutoLaunch {
+  const instance = new AutoLaunch(config);
+  if (process.platform === "linux" && process.env.APPIMAGE) {
+    (instance as any).opts.appPath = `${process.env.APPIMAGE} --no-sandbox`;
+  }
+  return instance;
+}
+
 // registerIpc listens to ipc requests\event
 function registerIpc() {
   let alConfig = { name: "Explorook", isHidden: true };
@@ -89,7 +105,7 @@ function registerIpc() {
   if (process.env.APPIMAGE) {
     alConfig = Object.assign(alConfig, { path: process.env.APPIMAGE });
   }
-  al = new AutoLaunch(alConfig);
+  al = createAutoLaunch(alConfig);
   linuxAutoLaunchPatch();
   firstTimeAutoLaunch();
   ipcMain.on("hidden", displayWindowHiddenNotification);


### PR DESCRIPTION
Ubuntu 24.04 introduced stricter kernel security restrictions that prevent Electron's chrome-sandbox from functioning inside an AppImage (FUSE-mounted filesystems cannot have SUID binaries). This causes a fatal crash on startup for all Linux users on Ubuntu 24+.

Two fixes applied, both are relevant only to Linux:

**package.json**: Added executableArgs: ["--no-sandbox"] to the electron-builder linux config, baking the flag into the AppImage so direct launches work correctly.
**src/index.ts**: Added createAutoLaunch that patches --no-sandbox into the Exec= line of the ~/.config/autostart/*.desktop file written by the auto-launch library, fixing the "Start with Linux" autostart feature.

Using the new appimage builder (1.0.2) to make sure appimage will use the relevant FUSE version (FUSE3 is used in 24+ versions and FUSE2 is used for older versions)


**The solution was tested on local VM with ubuntu 24.04 installed**