### PR TITLE
APPOBS-37628: add SKIP_WINDOWS_SIGNING env var and bump version to 1.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-desktop-application",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "dynatrace desktop application's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/sign_windows.mjs
+++ b/sign_windows.mjs
@@ -11,6 +11,11 @@ export default async function(configuration) {
   const CERTIFICATE_PATH = process.env.WINDOWS_EV_CERTIFICATE_PATH;
   const GOOGLE_HSM_KEY_ID = process.env.GOOGLE_HSM_KEY_ID;
 
+  if (process.env.SKIP_WINDOWS_SIGNING === 'true') {
+    console.log('Windows signing: SKIP_WINDOWS_SIGNING is set - skipping signing');
+    return true;
+  }
+
   // Skip signing if credentials are not available (e.g. local builds)
   if (!CERTIFICATE_PATH || !GOOGLE_HSM_KEY_ID) {
     console.log('Windows signing: credentials not found - skipping signing');


### PR DESCRIPTION
## Summary
- Adds `SKIP_WINDOWS_SIGNING=true` guard in `sign_windows.mjs` to allow producing an unsigned Windows binary via CI for manual re-signing
- Bumps version to `1.3.5`

## How to use
Before merging, set `SKIP_WINDOWS_SIGNING=true` as a project-level env var in CircleCI. The publish pipeline will build the Windows binary without signing.